### PR TITLE
feat: implementa telas admin RF26, RF27, RF29 e RF39

### DIFF
--- a/app/src/main/java/com/br/unifor/for_library/ForLibraryApp.kt
+++ b/app/src/main/java/com/br/unifor/for_library/ForLibraryApp.kt
@@ -14,10 +14,15 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.br.unifor.for_library.core.navigation.AdminBottomBar
 import com.br.unifor.for_library.core.navigation.ForLibraryBottomBar
 import com.br.unifor.for_library.core.navigation.Rota
 import com.br.unifor.for_library.feature.adm.TelaConfiguracoesSistema
 import com.br.unifor.for_library.feature.adm.acervo.TelaAdicionarObra
+import com.br.unifor.for_library.feature.adm.acervo.TelaEditarObra
+import com.br.unifor.for_library.feature.adm.acervo.TelaGestaoAcervo
+import com.br.unifor.for_library.feature.adm.dashboard.TelaDashboardAdmin
+import com.br.unifor.for_library.feature.adm.moderacao.TelaGestaoUsuarios
 import com.br.unifor.for_library.feature.adm.moderacao.modresenha.TelaAnaliseResenha
 import com.br.unifor.for_library.feature.adm.moderacao.modresenha.TelaModeracaoResenhas
 import com.br.unifor.for_library.feature.aluno.acervo.ui.TelaAcervoDigital
@@ -46,7 +51,12 @@ private val rotasComPadding = setOf(
     Rota.Acervo.path,
     Rota.Estante.path,
     Rota.Eventos.path,
-    Rota.Perfil.path
+    Rota.Perfil.path,
+    // Rotas admin com bottom bar
+    Rota.DashboardAdmin.path,
+    Rota.AcervoAdmin.path,
+    Rota.GestaoUsuarios.path,
+    Rota.EditarObra.path
 )
 
 @Composable
@@ -70,9 +80,23 @@ fun ForLibraryApp() {
             }
         )
     }
+    // Rotas que usam a bottom bar do Admin
+    val rotasAdmin = setOf(
+        Rota.DashboardAdmin.path,
+        Rota.AcervoAdmin.path,
+        Rota.GestaoUsuarios.path,
+        Rota.EditarObra.path
+    )
+
     // O Scaffold gerencia o layout da tela, incluindo a BottomBar
     Scaffold(
-        bottomBar = { ForLibraryBottomBar(navController = navController) }
+        bottomBar = {
+            if (rotaAtual in rotasAdmin) {
+                AdminBottomBar(navController = navController)
+            } else {
+                ForLibraryBottomBar(navController = navController)
+            }
+        }
     ) { paddingValues ->
 
         // Só aplica padding nas telas com bottom bar — null e rotas de auth ficam sem padding
@@ -108,7 +132,12 @@ fun ForLibraryApp() {
                         }
                     },
                     onIrParaCadastro     = {navController.navigate(Rota.ConfiguracoesSistema.path) },
-                    onIrParaEsqueciSenha = { navController.navigate(Rota.RecuperarSenha.path) }
+                    onIrParaEsqueciSenha = { navController.navigate(Rota.RecuperarSenha.path) },
+                    onAdm                = {
+                        navController.navigate(Rota.DashboardAdmin.path) {
+                            popUpTo(Rota.Login.path) { inclusive = true }
+                        }
+                    }
                 )
             }
 
@@ -243,6 +272,42 @@ fun ForLibraryApp() {
                 )
             }
 
+
+            // ── Dashboard Admin (RF26) ───────────────────────────────────────
+            composable(Rota.DashboardAdmin.path) {
+                TelaDashboardAdmin(
+                    onSinoClick = { navController.navigate(Rota.Notificacoes.path) },
+                    onVerTodasAtividades = { /* TODO */ }
+                )
+            }
+
+            // ── Gestão de Acervo (RF27) ──────────────────────────────────────
+            composable(Rota.AcervoAdmin.path) {
+                TelaGestaoAcervo(
+                    onVoltar = { navController.popBackStack() },
+                    onAdicionarLivro = { navController.navigate(Rota.AdicionarLivro.path) },
+                    onEditarLivro = { livroId ->
+                        navController.navigate(Rota.EditarObra.criarRota(livroId))
+                    },
+                    onExcluirLivro = { /* TODO */ }
+                )
+            }
+
+            // ── Editar Obra (RF29) ───────────────────────────────────────────
+            composable(Rota.EditarObra.path) { backStackEntry ->
+                val livroId = backStackEntry.arguments?.getString("livroId") ?: ""
+                TelaEditarObra(
+                    livroId = livroId,
+                    onVoltar = { navController.popBackStack() },
+                    onAtualizar = { navController.popBackStack() },
+                    onCancelar = { navController.popBackStack() }
+                )
+            }
+
+            // ── Gestão de Usuários (RF38 mínima → trigger RF39) ──────────────
+            composable(Rota.GestaoUsuarios.path) {
+                TelaGestaoUsuarios()
+            }
 
             // Moderação de obras
 

--- a/app/src/main/java/com/br/unifor/for_library/core/navigation/AdminBottomBar.kt
+++ b/app/src/main/java/com/br/unifor/for_library/core/navigation/AdminBottomBar.kt
@@ -1,0 +1,63 @@
+package com.br.unifor.for_library.core.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+private val itensAdmin = listOf(
+    ItemNav(Rota.DashboardAdmin,  "Dashboard",  Icons.Filled.Dashboard,    Icons.Outlined.Dashboard),
+    ItemNav(Rota.AcervoAdmin,     "Acervo",     Icons.Filled.LibraryBooks, Icons.Outlined.LibraryBooks),
+    ItemNav(Rota.GestaoUsuarios,  "Moderação",  Icons.Filled.Gavel,        Icons.Outlined.Gavel),
+    ItemNav(Rota.Eventos,         "Eventos",    Icons.Filled.Event,        Icons.Outlined.Event),
+)
+
+@Composable
+fun AdminBottomBar(navController: NavController) {
+    val backStack by navController.currentBackStackEntryAsState()
+    val rotaAtual = backStack?.destination?.route
+
+    val rotasComBarAdmin = listOf(
+        Rota.DashboardAdmin.path,
+        Rota.AcervoAdmin.path,
+        Rota.GestaoUsuarios.path,
+        Rota.EditarObra.path
+    )
+    if (rotaAtual !in rotasComBarAdmin) return
+
+    NavigationBar(containerColor = androidx.compose.ui.graphics.Color.White) {
+        itensAdmin.forEach { item ->
+            val selecionado = rotaAtual == item.rota.path
+            NavigationBarItem(
+                selected = selecionado,
+                onClick = {
+                    if (!selecionado) {
+                        navController.navigate(item.rota.path) {
+                            popUpTo(Rota.DashboardAdmin.path) { saveState = true }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    }
+                },
+                icon = {
+                    Icon(
+                        imageVector = if (selecionado) item.iconeSelecionado else item.iconeNormal,
+                        contentDescription = item.label
+                    )
+                },
+                label = { Text(item.label, fontSize = androidx.compose.ui.unit.TextUnit(10f, androidx.compose.ui.unit.TextUnitType.Sp)) },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = androidx.compose.ui.graphics.Color(0xFF1565C0),
+                    selectedTextColor = androidx.compose.ui.graphics.Color(0xFF1565C0),
+                    unselectedIconColor = androidx.compose.ui.graphics.Color(0xFF9E9E9E),
+                    unselectedTextColor = androidx.compose.ui.graphics.Color(0xFF9E9E9E),
+                    indicatorColor = androidx.compose.ui.graphics.Color(0xFFE3EEF9)
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/br/unifor/for_library/core/navigation/Rotas.kt
+++ b/app/src/main/java/com/br/unifor/for_library/core/navigation/Rotas.kt
@@ -12,10 +12,17 @@ sealed class Rota(val path: String) {
     object Configuracoes  : Rota("configuracoes")
 
     // NOVAS ROTAS ADM
+    object DashboardAdmin : Rota("dashboard_admin")
     object AcervoAdmin : Rota("acervo_admin")
     object AdicionarLivro : Rota("adicionar_livro")
 
+    object EditarObra : Rota("editar_obra/{livroId}") {
+        fun criarRota(livroId: String) = "editar_obra/$livroId"
+    }
+
     object PainelModeracao : Rota("painel_moderacao")
+
+    object GestaoUsuarios : Rota("gestao_usuarios")
 
     object ModeracaoResenhas : Rota("moderacao_resenhas")
 

--- a/app/src/main/java/com/br/unifor/for_library/feature/adm/acervo/TelaEditarObra.kt
+++ b/app/src/main/java/com/br/unifor/for_library/feature/adm/acervo/TelaEditarObra.kt
@@ -1,0 +1,313 @@
+package com.br.unifor.for_library.feature.adm.acervo
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.PictureAsPdf
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.br.unifor.for_library.core.components.CapaLivro
+import com.br.unifor.for_library.core.designsystem.AzulPrimario
+import com.br.unifor.for_library.core.designsystem.CinzaTexto
+
+private data class LivroEdicaoMock(
+    val id: String,
+    val titulo: String,
+    val autor: String,
+    val genero: String,
+    val ano: String,
+    val paginas: String,
+    val sinopse: String,
+    val isbn: String,
+    val arquivoNome: String,
+    val arquivoTamanho: String,
+    val capaAtualizadaHa: String
+)
+
+private val mockLivroEdicao = LivroEdicaoMock(
+    id = "1",
+    titulo = "Design System Essentials",
+    autor = "IBM Design Team",
+    genero = "Tecnologia",
+    ano = "2024",
+    paginas = "256",
+    sinopse = "A short text about the foundations of visual language in complex systems, covering scale, color theory, and modularity in digital products.",
+    isbn = "9780132350884",
+    arquivoNome = "essentials_v1.pdf",
+    arquivoTamanho = "4.2 MB",
+    capaAtualizadaHa = "2 dias"
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TelaEditarObra(
+    livroId: String,
+    onVoltar: () -> Unit,
+    onAtualizar: () -> Unit,
+    onCancelar: () -> Unit
+) {
+    val livro = mockLivroEdicao
+
+    var titulo by remember { mutableStateOf(livro.titulo) }
+    var autor by remember { mutableStateOf(livro.autor) }
+    var anoLancamento by remember { mutableStateOf(livro.ano) }
+    var paginas by remember { mutableStateOf(livro.paginas) }
+    var sinopse by remember { mutableStateOf(livro.sinopse) }
+
+    var generoSelecionado by remember { mutableStateOf(livro.genero) }
+    var menuExpandido by remember { mutableStateOf(false) }
+    val listaGeneros = listOf("Ficção", "Acadêmico", "Tecnologia", "Biografia", "História", "Design")
+
+    var arquivoAnexado by remember { mutableStateOf<Pair<String, String>?>(livro.arquivoNome to livro.arquivoTamanho) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Editar Obra", fontWeight = FontWeight.Bold, fontSize = 20.sp) },
+                navigationIcon = {
+                    IconButton(onClick = onVoltar) {
+                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Voltar")
+                    }
+                }
+            )
+        },
+        containerColor = Color.White
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 20.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // ── Capa do Livro (RF29.4) ─────────────────────────────────────────
+            Text("Capa do Livro", fontSize = 12.sp, fontWeight = FontWeight.Medium, color = Color.DarkGray)
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(8.dp),
+                colors = CardDefaults.cardColors(containerColor = Color(0xFFF9F9F9)),
+                border = BorderStroke(1.dp, Color(0xFFE0E0E0)),
+                elevation = CardDefaults.cardElevation(0.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    CapaLivro(
+                        isbn = livro.isbn,
+                        tituloFallback = livro.titulo,
+                        modifier = Modifier
+                            .width(60.dp)
+                            .height(84.dp)
+                            .clip(RoundedCornerShape(4.dp)),
+                        corFallback = AzulPrimario
+                    )
+                    Spacer(Modifier.width(12.dp))
+                    Column(Modifier.weight(1f)) {
+                        Text(
+                            livro.titulo,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 13.sp,
+                            color = Color(0xFF212121)
+                        )
+                        Spacer(Modifier.height(2.dp))
+                        Text(
+                            "Atualizada há ${livro.capaAtualizadaHa}",
+                            fontSize = 11.sp,
+                            color = CinzaTexto
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Button(
+                            onClick = { /* Abrir gerenciador de arquivos */ },
+                            modifier = Modifier.height(32.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = AzulPrimario),
+                            shape = RoundedCornerShape(4.dp),
+                            contentPadding = PaddingValues(horizontal = 12.dp)
+                        ) {
+                            Icon(Icons.Default.CameraAlt, contentDescription = null, tint = Color.White, modifier = Modifier.size(14.dp))
+                            Spacer(Modifier.width(6.dp))
+                            Text("Trocar Capa", color = Color.White, fontSize = 11.sp)
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // ── Campos do formulário (RF29.3) ─────────────────────────────────
+            FormInputEdicao(label = "Título", value = titulo, onValueChange = { titulo = it })
+            FormInputEdicao(label = "Autor", value = autor, onValueChange = { autor = it })
+
+            // Gênero (Dropdown)
+            Column(modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)) {
+                Text("Gênero", fontSize = 12.sp, fontWeight = FontWeight.Medium, color = Color.DarkGray)
+                Spacer(modifier = Modifier.height(6.dp))
+                ExposedDropdownMenuBox(
+                    expanded = menuExpandido,
+                    onExpandedChange = { menuExpandido = it }
+                ) {
+                    OutlinedTextField(
+                        value = generoSelecionado,
+                        onValueChange = {},
+                        readOnly = true,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .menuAnchor(),
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = menuExpandido) },
+                        shape = RoundedCornerShape(4.dp),
+                        colors = OutlinedTextFieldDefaults.colors(unfocusedBorderColor = Color(0xFFE0E0E0))
+                    )
+                    ExposedDropdownMenu(
+                        expanded = menuExpandido,
+                        onDismissRequest = { menuExpandido = false }
+                    ) {
+                        listaGeneros.forEach { item ->
+                            DropdownMenuItem(
+                                text = { Text(item) },
+                                onClick = {
+                                    generoSelecionado = item
+                                    menuExpandido = false
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Ano e Páginas (lado a lado)
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                Box(modifier = Modifier.weight(1f)) {
+                    FormInputEdicao(label = "Ano de Lançamento", value = anoLancamento, onValueChange = { if (it.length <= 4) anoLancamento = it })
+                }
+                Box(modifier = Modifier.weight(1f)) {
+                    FormInputEdicao(label = "Páginas", value = paginas, onValueChange = { paginas = it })
+                }
+            }
+
+            // Sinopse
+            FormInputEdicao(
+                label = "Sinopse",
+                value = sinopse,
+                onValueChange = { sinopse = it },
+                height = 100.dp,
+                singleLine = false
+            )
+
+            // ── Arquivo Digital (RF29.3) ──────────────────────────────────────
+            arquivoAnexado?.let { (nome, tamanho) ->
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(4.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color(0xFFFDEAEA)),
+                    border = BorderStroke(1.dp, Color(0xFFF8C9C9)),
+                    elevation = CardDefaults.cardElevation(0.dp)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            Icons.Default.PictureAsPdf,
+                            contentDescription = null,
+                            tint = Color(0xFFD32F2F),
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(Modifier.width(12.dp))
+                        Column(Modifier.weight(1f)) {
+                            Text(nome, fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = Color(0xFF212121))
+                            Text(tamanho, fontSize = 11.sp, color = CinzaTexto)
+                        }
+                        IconButton(onClick = { arquivoAnexado = null }) {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = "Remover arquivo",
+                                tint = Color(0xFFD32F2F),
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // ── Botões finais (RF29.5) ────────────────────────────────────────
+            Button(
+                onClick = onAtualizar,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = AzulPrimario),
+                shape = RoundedCornerShape(4.dp)
+            ) {
+                Text("Atualizar Obra", color = Color.White, fontWeight = FontWeight.SemiBold)
+            }
+
+            Spacer(Modifier.height(10.dp))
+
+            OutlinedButton(
+                onClick = onCancelar,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                shape = RoundedCornerShape(4.dp),
+                border = BorderStroke(1.dp, Color(0xFFE0E0E0))
+            ) {
+                Icon(Icons.Default.Close, contentDescription = null, tint = Color(0xFF424242), modifier = Modifier.size(16.dp))
+                Spacer(Modifier.width(8.dp))
+                Text("Cancelar", color = Color(0xFF424242))
+            }
+
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun FormInputEdicao(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    height: androidx.compose.ui.unit.Dp = 56.dp,
+    singleLine: Boolean = true
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)) {
+        Text(label, fontSize = 12.sp, fontWeight = FontWeight.Medium, color = Color.DarkGray)
+        Spacer(modifier = Modifier.height(6.dp))
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth().height(height),
+            singleLine = singleLine,
+            shape = RoundedCornerShape(4.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                unfocusedBorderColor = Color(0xFFE0E0E0),
+                focusedBorderColor = AzulPrimario
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/br/unifor/for_library/feature/adm/acervo/TelaGestaoAcervo.kt
+++ b/app/src/main/java/com/br/unifor/for_library/feature/adm/acervo/TelaGestaoAcervo.kt
@@ -1,0 +1,201 @@
+package com.br.unifor.for_library.feature.adm.acervo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.br.unifor.for_library.core.components.CapaLivro
+import com.br.unifor.for_library.core.designsystem.AzulPrimario
+import com.br.unifor.for_library.core.designsystem.CinzaTexto
+
+data class LivroAdminMock(
+    val id: String,
+    val titulo: String,
+    val autor: String,
+    val isbn: String
+)
+
+private val mockLivrosAdmin = listOf(
+    LivroAdminMock("1", "Design System Essentials", "IBM Design Team",     "9780132350884"),
+    LivroAdminMock("2", "The Grid System",          "Josef Müller-Brockmann","9783721201451"),
+    LivroAdminMock("3", "Accessibility in UI",      "Sara Soueidan",        "9781492053217"),
+    LivroAdminMock("4", "TypeScript Patterns",      "Dan Vanderkam",        "9781491904008"),
+    LivroAdminMock("5", "Enterprise Architecture",  "Martin Fowler",        "9780321127426"),
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TelaGestaoAcervo(
+    onVoltar: () -> Unit,
+    onAdicionarLivro: () -> Unit,
+    onEditarLivro: (String) -> Unit,
+    onExcluirLivro: (String) -> Unit
+) {
+    var busca by remember { mutableStateOf("") }
+    val livros = mockLivrosAdmin
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Gestão de Acervo", fontWeight = FontWeight.Bold, fontSize = 20.sp) },
+                navigationIcon = {
+                    IconButton(onClick = onVoltar) {
+                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Voltar")
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = onAdicionarLivro,
+                containerColor = AzulPrimario,
+                contentColor = Color.White,
+                shape = RoundedCornerShape(8.dp)
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Adicionar livro")
+            }
+        },
+        containerColor = Color.White
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp)
+        ) {
+            // ── Search Bar (RF27.2) ────────────────────────────────────────────
+            OutlinedTextField(
+                value = busca,
+                onValueChange = { busca = it },
+                placeholder = { Text("Busque por título ou autor", fontSize = 13.sp, color = Color.LightGray) },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null, tint = Color.Gray) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp),
+                singleLine = true,
+                shape = RoundedCornerShape(6.dp),
+                colors = OutlinedTextFieldDefaults.colors(
+                    unfocusedBorderColor = Color(0xFFE0E0E0),
+                    focusedBorderColor = AzulPrimario
+                )
+            )
+
+            // Quantidade de livros (RF27.2)
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp, bottom = 8.dp),
+                horizontalArrangement = Arrangement.End
+            ) {
+                Text(
+                    text = "${livros.size} livros",
+                    fontSize = 12.sp,
+                    color = CinzaTexto
+                )
+            }
+
+            // Lista de livros (RF27.3)
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+                contentPadding = PaddingValues(bottom = 80.dp)
+            ) {
+                items(livros) { livro ->
+                    ItemLivroAdmin(
+                        livro = livro,
+                        onEditar = { onEditarLivro(livro.id) },
+                        onExcluir = { onExcluirLivro(livro.id) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ItemLivroAdmin(
+    livro: LivroAdminMock,
+    onEditar: () -> Unit,
+    onExcluir: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFFE0E0E0)),
+        elevation = CardDefaults.cardElevation(0.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            CapaLivro(
+                isbn = livro.isbn,
+                tituloFallback = livro.titulo,
+                modifier = Modifier
+                    .width(48.dp)
+                    .height(64.dp)
+                    .clip(RoundedCornerShape(4.dp)),
+                corFallback = AzulPrimario
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    livro.titulo,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 13.sp,
+                    color = Color(0xFF212121),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    livro.autor,
+                    fontSize = 11.sp,
+                    color = CinzaTexto,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            // Editar (RF27.4)
+            IconButton(onClick = onEditar) {
+                Icon(
+                    Icons.Default.Edit,
+                    contentDescription = "Editar",
+                    tint = AzulPrimario,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            // Excluir (RF27.3)
+            IconButton(onClick = onExcluir) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = "Excluir",
+                    tint = Color(0xFFD32F2F),
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/br/unifor/for_library/feature/adm/dashboard/TelaDashboardAdmin.kt
+++ b/app/src/main/java/com/br/unifor/for_library/feature/adm/dashboard/TelaDashboardAdmin.kt
@@ -1,0 +1,253 @@
+package com.br.unifor.for_library.feature.adm.dashboard
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AssignmentTurnedIn
+import androidx.compose.material.icons.filled.Book
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.LibraryAdd
+import androidx.compose.material.icons.filled.MenuBook
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.RateReview
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.br.unifor.for_library.core.designsystem.AzulPrimario
+import com.br.unifor.for_library.core.designsystem.CinzaTexto
+
+private data class CardResumo(
+    val titulo: String,
+    val valor: String,
+    val icone: ImageVector,
+    val corFundo: Color,
+    val corIcone: Color,
+    val temAlerta: Boolean = false,
+    val corAlerta: Color = Color.Transparent
+)
+
+private data class AtividadeRecente(
+    val titulo: String,
+    val descricao: String,
+    val tempo: String,
+    val icone: ImageVector,
+    val corIcone: Color
+)
+
+private val mockResumos = listOf(
+    CardResumo("LIVROS NO ACERVO", "1.240", Icons.Default.MenuBook, Color(0xFFE3F2FD), Color(0xFF1976D2)),
+    CardResumo("ALUNOS ATIVOS",    "850",   Icons.Default.People,   Color(0xFFE3F2FD), Color(0xFF1976D2)),
+    CardResumo("RESENHAS PENDENTES", "12",  Icons.Default.RateReview, Color(0xFFFDEAEA), Color(0xFFD32F2F), temAlerta = true, corAlerta = Color(0xFFD32F2F)),
+    CardResumo("OBRAS PENDENTES",    "05",  Icons.Default.Book,    Color(0xFFE6F4EA), Color(0xFF388E3C), temAlerta = true, corAlerta = Color(0xFF388E3C)),
+)
+
+private val mockAtividades = listOf(
+    AtividadeRecente("Resenha aprovada",    "\"O Senhor dos Anéis\" - Por Marina Silva", "Há 15 minutos", Icons.Default.AssignmentTurnedIn, Color(0xFF1976D2)),
+    AtividadeRecente("Nova obra cadastrada","\"A Metamorfose\" - Edição Digital",         "Há 4 horas",    Icons.Default.LibraryAdd,         Color(0xFF1976D2)),
+    AtividadeRecente("Obra rejeitada",      "Título duplicado no catálogo",                "Há 1 dia",      Icons.Default.Cancel,             Color(0xFF1976D2)),
+    AtividadeRecente("Novo aluno registrado","João Pedro - Matrícula #851",                "Há 2 dias",     Icons.Default.PersonAdd,          Color(0xFF1976D2)),
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TelaDashboardAdmin(
+    nomeAdmin: String = "Admin",
+    onSinoClick: () -> Unit = {},
+    onVerTodasAtividades: () -> Unit = {},
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+            .verticalScroll(rememberScrollState())
+    ) {
+        // ── Header (RF26.1) ───────────────────────────────────────────────────
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Olá, $nomeAdmin!",
+                fontSize = 14.sp,
+                color = Color(0xFF424242),
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = onSinoClick) {
+                Icon(Icons.Default.Notifications, contentDescription = "Notificações", tint = Color(0xFF424242))
+            }
+        }
+
+        // ── Título (RF26.2) ───────────────────────────────────────────────────
+        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+            Text("Dashboard", fontSize = 24.sp, fontWeight = FontWeight.Bold, color = Color(0xFF212121))
+            Spacer(Modifier.height(2.dp))
+            Text(
+                "Visão geral do sistema e métricas principais",
+                fontSize = 12.sp,
+                color = CinzaTexto
+            )
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        // ── 4 Cards de Resumo (RF26.3) ────────────────────────────────────────
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            mockResumos.chunked(2).forEach { linha ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    linha.forEach { resumo ->
+                        CardResumoItem(resumo = resumo, modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        // ── Atividades Recentes (RF26.4 + RF26.5) ─────────────────────────────
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("Atividades Recentes", fontWeight = FontWeight.Bold, fontSize = 15.sp, color = Color(0xFF212121))
+            Text(
+                "Ver todas",
+                fontSize = 13.sp,
+                color = AzulPrimario,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.clickable { onVerTodasAtividades() }
+            )
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            mockAtividades.forEach { ItemAtividade(atividade = it) }
+        }
+
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun CardResumoItem(
+    resumo: CardResumo,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.height(110.dp),
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = resumo.corFundo),
+        elevation = CardDefaults.cardElevation(0.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(12.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = resumo.icone,
+                    contentDescription = null,
+                    tint = resumo.corIcone,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(Modifier.weight(1f))
+                if (resumo.temAlerta) {
+                    Box(
+                        modifier = Modifier
+                            .size(8.dp)
+                            .clip(CircleShape)
+                            .background(resumo.corAlerta)
+                    )
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = resumo.titulo,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = CinzaTexto,
+                letterSpacing = 0.4.sp
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = resumo.valor,
+                fontSize = 26.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF212121)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ItemAtividade(atividade: AtividadeRecente) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFF7F7F7)),
+        elevation = CardDefaults.cardElevation(0.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFFE3F2FD)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = atividade.icone,
+                    contentDescription = null,
+                    tint = atividade.corIcone,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(atividade.titulo, fontWeight = FontWeight.SemiBold, fontSize = 13.sp, color = Color(0xFF212121))
+                Spacer(Modifier.height(2.dp))
+                Text(atividade.descricao, fontSize = 11.sp, color = CinzaTexto)
+                Spacer(Modifier.height(2.dp))
+                Text(atividade.tempo, fontSize = 10.sp, color = Color(0xFF9E9E9E))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/br/unifor/for_library/feature/adm/moderacao/PopupDetalhesUsuario.kt
+++ b/app/src/main/java/com/br/unifor/for_library/feature/adm/moderacao/PopupDetalhesUsuario.kt
@@ -1,0 +1,170 @@
+package com.br.unifor.for_library.feature.adm.moderacao
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.br.unifor.for_library.core.designsystem.AzulPrimario
+import com.br.unifor.for_library.core.designsystem.CinzaTexto
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PopupDetalhesUsuario(
+    usuario: UsuarioMock,
+    onFechar: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var bloqueado by remember { mutableStateOf(!usuario.ativo) }
+
+    ModalBottomSheet(
+        onDismissRequest = onFechar,
+        sheetState = sheetState,
+        containerColor = Color.White
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp)
+        ) {
+            // RF39.2: Título
+            Text(
+                "Detalhes do Usuário",
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF212121)
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            // RF39.2: Dados Pessoais
+            Text(
+                "DADOS PESSOAIS",
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = CinzaTexto,
+                letterSpacing = 0.6.sp
+            )
+
+            Spacer(Modifier.height(10.dp))
+
+            CampoDado(label = "Nome Completo", valor = usuario.nome)
+            Spacer(Modifier.height(8.dp))
+            CampoDado(label = "Matrícula", valor = usuario.matricula)
+            Spacer(Modifier.height(8.dp))
+            CampoDado(label = "E-mail Institucional", valor = usuario.email)
+
+            Spacer(Modifier.height(16.dp))
+
+            // RF39.5: Card de Alerta — Status de Moderação
+            if (usuario.resenhasInadequadas > 0) {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(6.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color(0xFFFDEAEA)),
+                    border = BorderStroke(1.dp, Color(0xFFF8C9C9)),
+                    elevation = CardDefaults.cardElevation(0.dp)
+                ) {
+                    Row(
+                        modifier = Modifier.padding(12.dp),
+                        verticalAlignment = Alignment.Top
+                    ) {
+                        Icon(
+                            Icons.Default.Warning,
+                            contentDescription = null,
+                            tint = Color(0xFFD32F2F),
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Column {
+                            Text(
+                                "Status de Moderação",
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 13.sp,
+                                color = Color(0xFFB71C1C)
+                            )
+                            Spacer(Modifier.height(2.dp))
+                            Text(
+                                "Total de resenhas inadequadas: ${usuario.resenhasInadequadas}",
+                                fontSize = 12.sp,
+                                color = Color(0xFF424242)
+                            )
+                            if (usuario.resenhasInadequadas >= 3) {
+                                Spacer(Modifier.height(4.dp))
+                                Text(
+                                    "O usuário atingiu o limite de alertas automáticos do sistema.",
+                                    fontSize = 11.sp,
+                                    color = CinzaTexto
+                                )
+                            }
+                        }
+                    }
+                }
+                Spacer(Modifier.height(16.dp))
+            }
+
+            // RF39.3: Toggle Bloquear Acesso
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        "Bloquear Acesso à Plataforma",
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color(0xFF212121)
+                    )
+                    Text(
+                        "Impede login e interações no acervo",
+                        fontSize = 11.sp,
+                        color = CinzaTexto
+                    )
+                }
+                Switch(
+                    checked = bloqueado,
+                    onCheckedChange = { bloqueado = it },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = Color.White,
+                        checkedTrackColor = AzulPrimario,
+                        uncheckedThumbColor = Color.White,
+                        uncheckedTrackColor = Color(0xFFBDBDBD)
+                    )
+                )
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            // RF39.4: Botão Fechar
+            OutlinedButton(
+                onClick = onFechar,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(46.dp),
+                shape = RoundedCornerShape(4.dp),
+                border = BorderStroke(1.dp, AzulPrimario)
+            ) {
+                Text("Fechar", color = AzulPrimario, fontWeight = FontWeight.SemiBold)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CampoDado(label: String, valor: String) {
+    Column {
+        Text(label, fontSize = 11.sp, color = CinzaTexto)
+        Spacer(Modifier.height(2.dp))
+        Text(valor, fontSize = 13.sp, color = Color(0xFF212121))
+    }
+}

--- a/app/src/main/java/com/br/unifor/for_library/feature/adm/moderacao/TelaGestaoUsuarios.kt
+++ b/app/src/main/java/com/br/unifor/for_library/feature/adm/moderacao/TelaGestaoUsuarios.kt
@@ -1,0 +1,160 @@
+package com.br.unifor.for_library.feature.adm.moderacao
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.br.unifor.for_library.core.designsystem.AzulPrimario
+import com.br.unifor.for_library.core.designsystem.CinzaTexto
+
+data class UsuarioMock(
+    val id: String,
+    val nome: String,
+    val matricula: String,
+    val email: String,
+    val ativo: Boolean,
+    val resenhasInadequadas: Int
+)
+
+private val mockUsuarios = listOf(
+    UsuarioMock("1", "João Silva",     "2023001", "joao.silva@unifor.edu.br",     true,  0),
+    UsuarioMock("2", "Ana Oliveira",   "2023045", "ana.oliveira@unifor.edu.br",   false, 3),
+    UsuarioMock("3", "Ricardo Mendes", "2022112", "ricardo.mendes@unifor.edu.br", true,  1),
+    UsuarioMock("4", "Maria Santos",   "2023089", "maria.santos@unifor.edu.br",   true,  0),
+    UsuarioMock("5", "Pedro Costa",    "2021504", "pedro.costa@unifor.edu.br",    false, 3),
+    UsuarioMock("6", "Juliana Lima",   "2023156", "juliana.lima@unifor.edu.br",   true,  0),
+)
+
+@Composable
+fun TelaGestaoUsuarios() {
+    var busca by remember { mutableStateOf("") }
+    var usuarioSelecionado by remember { mutableStateOf<UsuarioMock?>(null) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+            .padding(horizontal = 16.dp)
+    ) {
+        Spacer(Modifier.height(16.dp))
+        Text(
+            "Gestão de Usuários",
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color(0xFF212121)
+        )
+        Spacer(Modifier.height(12.dp))
+
+        OutlinedTextField(
+            value = busca,
+            onValueChange = { busca = it },
+            placeholder = { Text("Buscar por matrícula ou nome", fontSize = 13.sp, color = Color.LightGray) },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null, tint = Color.Gray) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            shape = RoundedCornerShape(6.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                unfocusedBorderColor = Color(0xFFE0E0E0),
+                focusedBorderColor = AzulPrimario
+            )
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        Text(
+            "${mockUsuarios.size} USUÁRIOS ENCONTRADOS",
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = CinzaTexto,
+            letterSpacing = 0.5.sp
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(bottom = 16.dp)
+        ) {
+            items(mockUsuarios) { usuario ->
+                ItemUsuario(
+                    usuario = usuario,
+                    onClick = { usuarioSelecionado = usuario }
+                )
+            }
+        }
+    }
+
+    // RF39: Popup acionado ao clicar em um aluno
+    usuarioSelecionado?.let { usuario ->
+        PopupDetalhesUsuario(
+            usuario = usuario,
+            onFechar = { usuarioSelecionado = null }
+        )
+    }
+}
+
+@Composable
+private fun ItemUsuario(
+    usuario: UsuarioMock,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFF7F7F7)),
+        elevation = CardDefaults.cardElevation(0.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFFE0E0E0)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Default.Person, contentDescription = null, tint = Color(0xFF757575), modifier = Modifier.size(20.dp))
+            }
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(usuario.nome, fontWeight = FontWeight.SemiBold, fontSize = 13.sp, color = Color(0xFF212121))
+                Text("Matrícula: ${usuario.matricula}", fontSize = 11.sp, color = CinzaTexto)
+            }
+
+            // Status badge
+            val (corFundo, corTexto, label) = if (usuario.ativo) {
+                Triple(Color(0xFFE6F4EA), Color(0xFF1B873B), "ATIVO")
+            } else {
+                Triple(Color(0xFFFDEAEA), Color(0xFFD32F2F), "BLOQUEADO")
+            }
+            Box(
+                modifier = Modifier
+                    .background(corFundo, RoundedCornerShape(4.dp))
+                    .padding(horizontal = 8.dp, vertical = 3.dp)
+            ) {
+                Text(label, color = corTexto, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}


### PR DESCRIPTION
- RF26: Tela Dashboard do Administrador
- RF27: Tela de Gestão de Acervo
- RF29: Tela de Edição de Obra
- RF39: Popup de Detalhes do Usuário (+ RF38 mínima como trigger)
- Adiciona AdminBottomBar e novas rotas em Rotas.kt